### PR TITLE
Typo fix

### DIFF
--- a/Chapter11/simple_auto_encoder_with_different_latent_size.ipynb
+++ b/Chapter11/simple_auto_encoder_with_different_latent_size.ipynb
@@ -1644,7 +1644,7 @@
         "    show(im[0], ax=next(ax), title='input')\n",
         "    for model in aecs:\n",
         "        _im = model(im[None])[0]\n",
-        "        show(_im[0], ax=next(ax), title=f'prediction\\nlatent-dim:{model.latend_dim}')\n",
+        "        show(_im[0], ax=next(ax), title=f'prediction\\nlatent-dim:{model.latent_dim}')\n",
         "    plt.tight_layout()\n",
         "    plt.show()"
       ],


### PR DESCRIPTION
Fixed typo of `latend_dim` with `latent_dim` on the supporting workbook. 