### PR TITLE
Pretrained param is depreciated, fixed it.

### DIFF
--- a/Chapter05/VGG_architecture.ipynb
+++ b/Chapter05/VGG_architecture.ipynb
@@ -1,24 +1,10 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "name": "VGG_architecture.ipynb",
-      "provenance": [],
-      "authorship_tag": "ABX9TyPe/3ZXN0rsAfvPzmbfIYYW",
-      "include_colab_link": true
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    }
-  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "view-in-github"
       },
       "source": [
         "<a href=\"https://colab.research.google.com/github/PacktPublishing/Modern-Computer-Vision-with-PyTorch-2E/blob/main/Chapter05/VGG_architecture.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
@@ -26,6 +12,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": 1,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -33,6 +20,15 @@
         "id": "ZGFMlprVNhM9",
         "outputId": "87d633f5-43a1-4f2b-b1f9-cd0c50d88553"
       },
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Requirement already satisfied: torch_summary in /usr/local/lib/python3.6/dist-packages (1.4.3)\n"
+          ]
+        }
+      ],
       "source": [
         "import torchvision\n",
         "import torch.nn as nn\n",
@@ -42,31 +38,24 @@
         "%pip install torch_summary\n",
         "from torchsummary import summary\n",
         "device = 'cuda' if torch.cuda.is_available() else 'cpu'"
-      ],
-      "execution_count": 1,
-      "outputs": [
-        {
-          "output_type": "stream",
-          "text": [
-            "Requirement already satisfied: torch_summary in /usr/local/lib/python3.6/dist-packages (1.4.3)\n"
-          ],
-          "name": "stdout"
-        }
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 2,
       "metadata": {
         "id": "3VRuWU7rNjNq"
       },
+      "outputs": [],
       "source": [
-        "model = models.vgg16(pretrained=True).to(device)"
-      ],
-      "execution_count": 2,
-      "outputs": []
+        "from torchvision.models import VGG16_Weights\n",
+        "\n",
+        "model = models.vgg16(weights=VGG16_Weights.DEFAULT)"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": 3,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -74,12 +63,9 @@
         "id": "lQ9BIH_QNkyY",
         "outputId": "f7f6af55-29b7-4df6-8974-3e80abd635f1"
       },
-      "source": [
-        "summary(model, torch.zeros(1,3,224,224));"
-      ],
-      "execution_count": 3,
       "outputs": [
         {
+          "name": "stdout",
           "output_type": "stream",
           "text": [
             "==========================================================================================\n",
@@ -137,13 +123,16 @@
             "Params size (MB): 527.79\n",
             "Estimated Total Size (MB): 631.80\n",
             "==========================================================================================\n"
-          ],
-          "name": "stdout"
+          ]
         }
+      ],
+      "source": [
+        "summary(model, torch.zeros(1,3,224,224));"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 4,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -151,13 +140,8 @@
         "id": "StQBD486NmM-",
         "outputId": "612481e0-7665-4b5c-9c5a-ebf76f335178"
       },
-      "source": [
-        "model"
-      ],
-      "execution_count": 4,
       "outputs": [
         {
-          "output_type": "execute_result",
           "data": {
             "text/plain": [
               "VGG(\n",
@@ -207,23 +191,39 @@
               ")"
             ]
           },
+          "execution_count": 4,
           "metadata": {
             "tags": []
           },
-          "execution_count": 4
+          "output_type": "execute_result"
         }
+      ],
+      "source": [
+        "model"
       ]
     },
     {
       "cell_type": "code",
+      "execution_count": 4,
       "metadata": {
         "id": "TBnhG2vTNr8R"
       },
-      "source": [
-        ""
-      ],
-      "execution_count": 4,
-      "outputs": []
+      "outputs": [],
+      "source": []
     }
-  ]
+  ],
+  "metadata": {
+    "colab": {
+      "authorship_tag": "ABX9TyPe/3ZXN0rsAfvPzmbfIYYW",
+      "include_colab_link": true,
+      "name": "VGG_architecture.ipynb",
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/Chapter05/VGG_architecture.ipynb
+++ b/Chapter05/VGG_architecture.ipynb
@@ -50,7 +50,7 @@
       "source": [
         "from torchvision.models import VGG16_Weights\n",
         "\n",
-        "model = models.vgg16(weights=VGG16_Weights.DEFAULT)"
+        "model = models.vgg16(weights=VGG16_Weights.DEFAULT).to(device)"
       ]
     },
     {


### PR DESCRIPTION
If you load a pretrained model and use the pretrained param for model weights then it throws warnings because it's depreciated. And it's not gonna work for future pytorch versions. So fixed the issue according to the current API.